### PR TITLE
Feature: Add Geocentric module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,10 @@ message (STATUS
 
 # Set source files here since they are used in multiple places
 set (PYTHON_FILES
-  accumulator.py constants.py geodesiccapability.py
+  accumulator.py constants.py geocentric.py geodesiccapability.py
   geodesicline.py geodesic.py geomath.py polygonarea.py)
 set (TEST_FILES
-  test/__init__.py test/test_geodesic.py test/test_sign.py)
+  test/__init__.py test/test_geocentric.py test/test_geodesic.py test/test_sign.py)
 
 add_subdirectory (geographiclib)
 
@@ -52,6 +52,8 @@ enable_testing ()
 # Run the test suite
 add_test (NAME testsuite
   COMMAND ${Python_EXECUTABLE} -m unittest -v geographiclib.test.test_geodesic)
+add_test (NAME testgeocentric
+  COMMAND ${Python_EXECUTABLE} -m unittest -v geographiclib.test.test_geocentric)
 add_test (NAME testsign
   COMMAND ${Python_EXECUTABLE} -m unittest -v geographiclib.test.test_sign)
 

--- a/doc/code.rst
+++ b/doc/code.rst
@@ -6,6 +6,11 @@ geographiclib
 .. automodule:: geographiclib
    :members: __version_info__, __version__
 
+geographiclib.geocentric
+------------------------
+.. automodule:: geographiclib.geocentric
+   :members:
+
 geographiclib.geodesic
 ----------------------
 .. automodule:: geographiclib.geodesic

--- a/geographiclib/geocentric.py
+++ b/geographiclib/geocentric.py
@@ -1,0 +1,301 @@
+"""geocentric.py: transcription of GeographicLib::Geocentric class."""
+# geocentric.py
+#
+# This is a rather literal translation of the GeographicLib::Geocentric class
+# to python.  See the documentation for the C++ class for more information at
+#
+#    https://geographiclib.sourceforge.io/C++/doc/annotated.html
+#
+# Copyright (c) Charles Karney (2008-2022) <karney@alum.mit.edu> and
+# licensed under the MIT/X11 License.  For more information, see
+# https://geographiclib.sourceforge.io/
+######################################################################
+
+from typing import TypeVar
+import math
+import sys
+
+from geographiclib.geomath import Math
+from geographiclib.constants import Constants
+
+
+T = TypeVar('T', bound='Geocentric')
+
+class Geocentric:
+  """
+  Convert between geodetic and geocentric coordinates.
+
+  Convert between geodetic coordinates latitude = lat, longitude = lon,
+  height = h (measured vertically from the surface of the ellipsoid) to
+  geocentric coordinates (X, Y, Z).  The origin of geocentric coordinates
+  is at the center of the earth.  The Z axis goes through the north pole,
+  lat = 90°.  The X axis goes through lat = 0, lon = 0.  Geocentric
+  coordinates are also known as earth centered, earth fixed (ECEF)
+  coordinates.
+
+  The conversion from geographic to geocentric coordinates is
+  straightforward.  For the reverse transformation we use H. Vermeille,
+  "Direct transformation from geocentric coordinates to geodetic
+  coordinates", J. Geodesy 76, 451-454 (2002).
+
+  Several changes have been made to ensure that the method returns accurate
+  results for all finite inputs (even if h is infinite).  See C. F. F. Karney,
+  "Geodesics on an ellipsoid of revolution", arxiv:1102.1215v1 (2011),
+  Appendix B.
+  """
+
+  def __init__(self, a, f):
+    """
+    Construct a Geocentric object.
+
+    :param a: the equatorial radius of the ellipsoid (meters)
+    :param f: the flattening of the ellipsoid
+
+    An exception is thrown if either of the axes of the ellipsoid is
+    not positive.
+    """
+    self.a = float(a)
+    """The equatorial radius in meters (readonly)"""
+    self.f = float(f)
+    """The flattening (readonly)"""
+    self._e2 = self.f * (2 - self.f)
+    self._e2m = Math.sq(1 - self.f)  # 1 - _e2
+    self._e2a = abs(self._e2)
+    self._e4a = Math.sq(self._e2)
+    self._maxrad = 2 * self.a / sys.float_info.epsilon
+
+    if not (math.isfinite(self.a) and self.a > 0):
+      raise ValueError("Equatorial radius is not positive")
+    if not (math.isfinite(self.f) and self.f < 1):
+      raise ValueError("Polar semi-axis is not positive")
+
+  @staticmethod
+  def _Rotation(sphi, cphi, slam, clam):
+    """
+    Compute the rotation matrix from local ENU to geocentric XYZ coordinates.
+
+    :param sphi: sine of latitude
+    :param cphi: cosine of latitude
+    :param slam: sine of longitude
+    :param clam: cosine of longitude
+    :return: 9-element list representing 3x3 rotation matrix in row-major order
+
+    The rotation matrix M transforms a vector v in local ENU (East, North, Up)
+    coordinates to geocentric XYZ coordinates: v_XYZ = M · v_ENU
+    """
+    # This rotation matrix is given by the following quaternion operations
+    # qrot(lam, [0,0,1]) * qrot(phi, [0,-1,0]) * [1,1,1,1]/2
+    # or
+    # qrot(pi/2 + lam, [0,0,1]) * qrot(-pi/2 + phi , [-1,0,0])
+    return [
+        # Local X axis (east) in geocentric coords
+        -slam,        clam,         0,
+        # Local Y axis (north) in geocentric coords
+        -clam * sphi, -slam * sphi, cphi,
+        # Local Z axis (up) in geocentric coords
+        clam * cphi,  slam * cphi,  sphi
+    ]
+
+  @staticmethod
+  def _Rotate(M, x, y, z):
+    """
+    Apply rotation matrix M to transform from local to geocentric coordinates.
+
+    :param M: 9-element rotation matrix in row-major order
+    :param x: local x coordinate (east)
+    :param y: local y coordinate (north)
+    :param z: local z coordinate (up)
+    :return: tuple (X, Y, Z) in geocentric coordinates
+
+    Performs [X, Y, Z]^T = M · [x, y, z]^T
+    """
+    X = M[0] * x + M[1] * y + M[2] * z
+    Y = M[3] * x + M[4] * y + M[5] * z
+    Z = M[6] * x + M[7] * y + M[8] * z
+    return X, Y, Z
+
+  @staticmethod
+  def _Unrotate(M, X, Y, Z):
+    """
+    Apply inverse rotation matrix M^T to transform from geocentric to local.
+
+    :param M: 9-element rotation matrix in row-major order
+    :param X: geocentric X coordinate
+    :param Y: geocentric Y coordinate
+    :param Z: geocentric Z coordinate
+    :return: tuple (x, y, z) in local ENU coordinates
+
+    Performs [x, y, z]^T = M^T · [X, Y, Z]^T
+    """
+    x = M[0] * X + M[3] * Y + M[6] * Z
+    y = M[1] * X + M[4] * Y + M[7] * Z
+    z = M[2] * X + M[5] * Y + M[8] * Z
+    return x, y, z
+
+  def Forward(self, lat, lon, h, M=False):
+    """
+    Convert from geodetic to geocentric coordinates.
+
+    :param lat: latitude of point (degrees)
+    :param lon: longitude of point (degrees)
+    :param h: height of point above the ellipsoid (meters)
+    :param M: if True, include the rotation matrix in the result
+    :return: a dictionary with the following key/value pairs:
+
+      * X: geocentric coordinate (meters)
+      * Y: geocentric coordinate (meters)
+      * Z: geocentric coordinate (meters)
+      * M: (only if M=True) rotation matrix as 9-element list (row-major order)
+
+    lat should be in the range [-90°, 90°].
+
+    If M is True, the rotation matrix M transforms a unit vector v in local
+    ENU (East, North, Up) coordinates to geocentric XYZ coordinates via
+    v_XYZ = M · v_ENU.
+    """
+    sphi, cphi = Math.sincosd(Math.LatFix(lat))
+    slam, clam = Math.sincosd(lon)
+    n = self.a / math.sqrt(1 - self._e2 * Math.sq(sphi))
+    Z = (self._e2m * n + h) * sphi
+    X = (n + h) * cphi
+    Y = X * slam
+    X *= clam
+    result = {'X': X, 'Y': Y, 'Z': Z}
+    if M:
+      result['M'] = self._Rotation(sphi, cphi, slam, clam)
+    return result
+
+  def Reverse(self, X, Y, Z, M=False):
+    """
+    Convert from geocentric to geodetic coordinates.
+
+    :param X: geocentric coordinate (meters)
+    :param Y: geocentric coordinate (meters)
+    :param Z: geocentric coordinate (meters)
+    :param M: if True, include the rotation matrix in the result
+    :return: a dictionary with the following key/value pairs:
+
+      * lat: latitude of point (degrees)
+      * lon: longitude of point (degrees)
+      * h: height of point above the ellipsoid (meters)
+      * M: (only if M=True) rotation matrix as 9-element list (row-major order)
+
+    In general, there are multiple solutions and the result which minimizes
+    the absolute value of h is returned, i.e., (lat, lon) corresponds to the
+    closest point on the ellipsoid.  The value of lon returned is in the
+    range [-180°, 180°].
+
+    If M is True, the rotation matrix M transforms a unit vector v in local
+    ENU (East, North, Up) coordinates to geocentric XYZ coordinates via
+    v_XYZ = M · v_ENU. The inverse transformation is v_ENU = M^T · v_XYZ.
+    """
+    R = math.hypot(X, Y)
+    slam = Y / R if R != 0 else 0
+    clam = X / R if R != 0 else 1
+    h = math.hypot(R, Z)  # Distance to center of earth
+
+    if h > self._maxrad:
+      # We are really far away (> 12 million light years); treat the earth
+      # as a point and h, above, is an acceptable approximation to the
+      # height.  This avoids overflow, e.g., in the computation of disc
+      # below.  It's possible that h has overflowed to inf; but that's OK.
+      #
+      # Treat the case X, Y finite, but R overflows to +inf by scaling by 2.
+      R = math.hypot(X / 2, Y / 2)
+      slam = (Y / 2) / R if R != 0 else 0
+      clam = (X / 2) / R if R != 0 else 1
+      H = math.hypot(Z / 2, R)
+      sphi = (Z / 2) / H
+      cphi = R / H
+    elif self._e4a == 0:
+      # Treat the spherical case.  Dealing with underflow in the general
+      # case with _e2 = 0 is difficult.  Origin maps to N pole same as
+      # with ellipsoid.
+      H = math.hypot(1 if h == 0 else Z, R)
+      sphi = (1 if h == 0 else Z) / H
+      cphi = R / H
+      h -= self.a
+    else:
+      # Treat prolate spheroids by swapping R and Z here and by switching
+      # the arguments to phi = atan2(...) at the end.
+      p = Math.sq(R / self.a)
+      q = self._e2m * Math.sq(Z / self.a)
+      r = (p + q - self._e4a) / 6
+      if self.f < 0:
+        p, q = q, p
+      if not (self._e4a * q == 0 and r <= 0):
+        # Avoid possible division by zero when r = 0 by multiplying
+        # equations for s and t by r^3 and r, resp.
+        S = self._e4a * p * q / 4  # S = r^3 * s
+        r2 = Math.sq(r)
+        r3 = r * r2
+        disc = S * (2 * r3 + S)
+        u = r
+        if disc >= 0:
+          T3 = S + r3
+          # Pick the sign on the sqrt to maximize abs(T3).  This minimizes
+          # loss of precision due to cancellation.  The result is unchanged
+          # because of the way T is used in the definition of u.
+          T3 += -math.sqrt(disc) if T3 < 0 else math.sqrt(disc)  # T3 = (r * t)^3
+          # N.B. cbrt always returns the real root.  cbrt(-8) = -2.
+          T = Math.cbrt(T3)  # T = r * t
+          # T can be zero; but then r2 / T -> 0.
+          u += T + (r2 / T if T != 0 else 0)
+        else:
+          # T is complex, but the way u is defined the result is real.
+          ang = math.atan2(math.sqrt(-disc), -(S + r3))
+          # There are three possible cube roots.  We choose the root which
+          # avoids cancellation.  Note that disc < 0 implies that r < 0.
+          u += 2 * r * math.cos(ang / 3)
+
+        v = math.sqrt(Math.sq(u) + self._e4a * q)  # guaranteed positive
+        # Avoid loss of accuracy when u < 0.  Underflow doesn't occur in
+        # e4 * q / (v - u) because u ~ e^4 when q is small and u < 0.
+        uv = self._e4a * q / (v - u) if u < 0 else u + v  # u+v, guaranteed positive
+        # Need to guard against w going negative due to roundoff in uv - q.
+        w = max(0.0, self._e2a * (uv - q) / (2 * v))
+        # Rearrange expression for k to avoid loss of accuracy due to
+        # subtraction.  Division by 0 not possible because uv > 0, w >= 0.
+        k = uv / (math.sqrt(uv + Math.sq(w)) + w)
+        k1 = k if self.f >= 0 else k - self._e2
+        k2 = k + self._e2 if self.f >= 0 else k
+        d = k1 * R / k2
+        H = math.hypot(Z / k1, R / k2)
+        sphi = (Z / k1) / H
+        cphi = (R / k2) / H
+        h = (1 - self._e2m / k1) * math.hypot(d, Z)
+      else:  # e4 * q == 0 && r <= 0
+        # This leads to k = 0 (oblate, equatorial plane) and k + e^2 = 0
+        # (prolate, rotation axis) and the generation of 0/0 in the general
+        # formulas for phi and h.  using the general formula and target_lon by 0
+        # in formula for h.  So handle this case by taking the limits:
+        # f > 0: z -> 0, k      ->   e2 * sqrt(q)/sqrt(e4 - p)
+        # f < 0: R -> 0, k + e2 -> - e2 * sqrt(q)/sqrt(e4 - p)
+        zz = math.sqrt((self._e4a - p if self.f >= 0 else p) / self._e2m)
+        xx = math.sqrt(self._e4a - p if self.f < 0 else p)
+        H = math.hypot(zz, xx)
+        sphi = zz / H
+        cphi = xx / H
+        if Z < 0:
+          sphi = -sphi  # for tiny negative Z (not for prolate)
+        h = -self.a * (self._e2m if self.f >= 0 else 1) * H / self._e2a
+
+    lat = Math.atan2d(sphi, cphi)
+    lon = Math.atan2d(slam, clam)
+    result = {'lat': lat, 'lon': lon, 'h': h}
+    if M:
+      result['M'] = self._Rotation(sphi, cphi, slam, clam)
+    return result
+
+  def EquatorialRadius(self):
+    """Return the equatorial radius of the ellipsoid (meters)."""
+    return self.a
+
+  def Flattening(self):
+    """Return the flattening of the ellipsoid."""
+    return self.f
+
+  @classmethod
+  def WGS84(cls) -> T:
+      """Instantiation for the WGS84 ellipsoid"""
+      return cls(a=Constants.WGS84_a, f=Constants.WGS84_f)

--- a/geographiclib/test/test_geocentric.py
+++ b/geographiclib/test/test_geocentric.py
@@ -1,0 +1,267 @@
+"""Geocentric tests"""
+
+import unittest
+
+from geographiclib.geocentric import Geocentric
+
+
+class GeocentricTest(unittest.TestCase):
+  """Geocentric test suite"""
+
+  def setUp(self):
+      """Instantiate WGS84 Geocentric instance"""
+      self.geoc = Geocentric.WGS84()
+
+  def test_forward_origin(self):
+    """Test Forward at equator/prime meridian"""
+    result = self.geoc.Forward(0, 0, 0)
+    self.assertAlmostEqual(result['X'], 6378137.0, places=3)
+    self.assertAlmostEqual(result['Y'], 0.0, places=10)
+    self.assertAlmostEqual(result['Z'], 0.0, places=10)
+
+  def test_forward_north_pole(self):
+    """Test Forward at north pole"""
+    result = self.geoc.Forward(90, 0, 0)
+    self.assertAlmostEqual(result['X'], 0.0, places=3)
+    self.assertAlmostEqual(result['Y'], 0.0, places=3)
+    # Polar radius b = a * (1 - f)
+    b = self.geoc.a * (1 - self.geoc.f)
+    self.assertAlmostEqual(result['Z'], b, places=3)
+
+  def test_forward_south_pole(self):
+    """Test Forward at south pole"""
+    result = self.geoc.Forward(-90, 0, 0)
+    self.assertAlmostEqual(result['X'], 0.0, places=3)
+    self.assertAlmostEqual(result['Y'], 0.0, places=3)
+    b = self.geoc.a * (1 - self.geoc.f)
+    self.assertAlmostEqual(result['Z'], -b, places=3)
+
+  def test_forward_with_height(self):
+    """Test Forward with non-zero height"""
+    h = 1000.0  # 1 km altitude
+    result = self.geoc.Forward(0, 0, h)
+    self.assertAlmostEqual(result['X'], 6378137.0 + h, places=3)
+    self.assertAlmostEqual(result['Y'], 0.0, places=10)
+    self.assertAlmostEqual(result['Z'], 0.0, places=10)
+
+  def test_roundtrip_equator(self):
+    """Test Forward->Reverse roundtrip at equator"""
+    lat, lon, h = 0.0, 45.0, 100.0
+    fwd = self.geoc.Forward(lat, lon, h)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_roundtrip_midlatitude(self):
+    """Test Forward->Reverse roundtrip at mid-latitude"""
+    lat, lon, h = 48.8566, 2.3522, 35.0  # Paris
+    fwd = self.geoc.Forward(lat, lon, h)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_roundtrip_high_latitude(self):
+    """Test Forward->Reverse roundtrip at high latitude"""
+    lat, lon, h = 78.2232, 15.6267, 10.0  # Longyearbyen, Svalbard
+    fwd = self.geoc.Forward(lat, lon, h)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_roundtrip_negative_longitude(self):
+    """Test Forward->Reverse roundtrip with negative longitude"""
+    lat, lon, h = 40.7128, -74.0060, 10.0  # New York
+    fwd = self.geoc.Forward(lat, lon, h)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_roundtrip_southern_hemisphere(self):
+    """Test Forward->Reverse roundtrip in southern hemisphere"""
+    lat, lon, h = -33.8688, 151.2093, 58.0  # Sydney
+    fwd = self.geoc.Forward(lat, lon, h)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_roundtrip_high_altitude(self):
+    """Test Forward->Reverse roundtrip at high altitude"""
+    lat, lon, h = 0.0, 0.0, 35786000.0  # Geostationary orbit
+    fwd = self.geoc.Forward(lat, lon, h)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=3)
+
+  def test_roundtrip_poles(self):
+    """Test Forward->Reverse roundtrip at poles"""
+    for lat in [90.0, -90.0]:
+      h = 0.0
+      fwd = self.geoc.Forward(lat, 0, h)
+      rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+      self.assertAlmostEqual(rev['lat'], lat, places=10)
+      # Longitude is undefined at poles, so we don't check it
+      self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_reverse_origin(self):
+    """Test Reverse at earth center returns pole"""
+    rev = self.geoc.Reverse(0, 0, 0)
+    # At origin, lat should be 90 (north pole), h negative
+    self.assertAlmostEqual(rev['lat'], 90.0, places=10)
+    self.assertAlmostEqual(rev['lon'], 0.0, places=10)
+
+  def test_spherical_ellipsoid(self):
+    """Test with spherical earth (f=0)"""
+    R = 6371000.0  # Mean earth radius
+    sphere = Geocentric(R, 0)
+
+    # Forward at equator
+    fwd = sphere.Forward(0, 0, 0)
+    self.assertAlmostEqual(fwd['X'], R, places=3)
+    self.assertAlmostEqual(fwd['Y'], 0.0, places=10)
+    self.assertAlmostEqual(fwd['Z'], 0.0, places=10)
+
+    # Roundtrip
+    lat, lon, h = 45.0, 90.0, 1000.0
+    fwd = sphere.Forward(lat, lon, h)
+    rev = sphere.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_custom_ellipsoid(self):
+    """Test with custom ellipsoid"""
+    # GRS80 ellipsoid
+    a = 6378137.0
+    f = 1/298.257222101
+    grs80 = Geocentric(a, f)
+
+    lat, lon, h = 45.0, 45.0, 500.0
+    fwd = grs80.Forward(lat, lon, h)
+    rev = grs80.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+    self.assertAlmostEqual(rev['lat'], lat, places=10)
+    self.assertAlmostEqual(rev['lon'], lon, places=10)
+    self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_invalid_radius(self):
+    """Test that invalid radius raises ValueError"""
+    with self.assertRaises(ValueError):
+      Geocentric(-1, 0.003)
+    with self.assertRaises(ValueError):
+      Geocentric(0, 0.003)
+
+  def test_invalid_flattening(self):
+    """Test that invalid flattening raises ValueError"""
+    # f >= 1 means polar semi-axis is not positive
+    with self.assertRaises(ValueError):
+      Geocentric(6378137, 1.0)
+    with self.assertRaises(ValueError):
+      Geocentric(6378137, 2.0)
+
+  def test_dateline_crossing(self):
+    """Test coordinates near dateline"""
+    for lon in [179.9, 180.0, -179.9, -180.0]:
+      lat, h = 0.0, 0.0
+      fwd = self.geoc.Forward(lat, lon, h)
+      rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'])
+      self.assertAlmostEqual(rev['lat'], lat, places=10)
+      # Normalize longitude for comparison
+      expected_lon = lon if -180 <= lon <= 180 else lon - 360 if lon > 180 else lon + 360
+      self.assertAlmostEqual(rev['lon'], expected_lon, places=10)
+      self.assertAlmostEqual(rev['h'], h, places=6)
+
+  def test_equatorial_radius(self):
+    """Test EquatorialRadius inspector method"""
+    self.assertEqual(self.geoc.EquatorialRadius(), self.geoc.a)
+
+  def test_flattening(self):
+    """Test Flattening inspector method"""
+    self.assertEqual(self.geoc.Flattening(), self.geoc.f)
+
+  def test_forward_with_rotation_matrix(self):
+    """Test Forward with M=True returns rotation matrix"""
+    result = self.geoc.Forward(45.0, 90.0, 0, M=True)
+    self.assertIn('M', result)
+    self.assertEqual(len(result['M']), 9)
+
+  def test_reverse_with_rotation_matrix(self):
+    """Test Reverse with M=True returns rotation matrix"""
+    result = self.geoc.Reverse(6378137.0, 0, 0, M=True)
+    self.assertIn('M', result)
+    self.assertEqual(len(result['M']), 9)
+
+  def test_forward_without_m_no_matrix(self):
+    """Test Forward without M parameter does not include rotation matrix"""
+    result = self.geoc.Forward(45.0, 90.0, 0)
+    self.assertNotIn('M', result)
+
+  def test_reverse_without_m_no_matrix(self):
+    """Test Reverse without M parameter does not include rotation matrix"""
+    result = self.geoc.Reverse(6378137.0, 0, 0)
+    self.assertNotIn('M', result)
+
+  def test_rotation_matrix_orthonormal(self):
+    """Test that rotation matrix is orthonormal (M * M^T = I)"""
+    import math
+    result = self.geoc.Forward(45.0, 45.0, 0, M=True)
+    M = result['M']
+
+    # Check that M * M^T = I (within numerical precision)
+    # M is row-major: M[0:3] is row 0, M[3:6] is row 1, M[6:9] is row 2
+    for i in range(3):
+      for j in range(3):
+        # Compute (M * M^T)[i,j] = sum_k M[i,k] * M[j,k]
+        dot = sum(M[i*3 + k] * M[j*3 + k] for k in range(3))
+        expected = 1.0 if i == j else 0.0
+        self.assertAlmostEqual(dot, expected, places=14,
+          msg=f"M*M^T[{i},{j}] = {dot}, expected {expected}")
+
+  def test_rotate_unrotate_inverse(self):
+    """Test that _Rotate and _Unrotate are inverses"""
+    result = self.geoc.Forward(30.0, 60.0, 1000.0, M=True)
+    M = result['M']
+
+    # Apply rotation then inverse
+    x, y, z = 100.0, 200.0, 300.0
+    X, Y, Z = Geocentric._Rotate(M, x, y, z)
+    x2, y2, z2 = Geocentric._Unrotate(M, X, Y, Z)
+
+    self.assertAlmostEqual(x2, x, places=10)
+    self.assertAlmostEqual(y2, y, places=10)
+    self.assertAlmostEqual(z2, z, places=10)
+
+  def test_rotation_equator_prime_meridian(self):
+    """Test rotation matrix at equator/prime meridian"""
+    result = self.geoc.Forward(0, 0, 0, M=True)
+    M = result['M']
+    # At lat=0, lon=0:
+    # East (local X) -> -Y geocentric (slam=0, clam=1, so M[0]=-0, M[1]=1, M[2]=0)
+    # North (local Y) -> -Z geocentric direction for north
+    # Up (local Z) -> +X geocentric
+    # M[0], M[1], M[2] = -slam, clam, 0 = 0, 1, 0
+    self.assertAlmostEqual(M[0], 0.0, places=14)  # -slam
+    self.assertAlmostEqual(M[1], 1.0, places=14)  # clam
+    self.assertAlmostEqual(M[2], 0.0, places=14)  # 0
+
+  def test_rotation_north_pole(self):
+    """Test rotation matrix at north pole"""
+    result = self.geoc.Forward(90, 0, 0, M=True)
+    M = result['M']
+    # At north pole: sphi=1, cphi=0, slam=0, clam=1
+    # Up (local Z) should point to +Z geocentric
+    self.assertAlmostEqual(M[8], 1.0, places=14)  # sphi
+
+  def test_forward_reverse_rotation_matrices_match(self):
+    """Test that Forward and Reverse produce the same rotation matrix"""
+    lat, lon, h = 45.0, 90.0, 1000.0
+    fwd = self.geoc.Forward(lat, lon, h, M=True)
+    rev = self.geoc.Reverse(fwd['X'], fwd['Y'], fwd['Z'], M=True)
+
+    for i in range(9):
+      self.assertAlmostEqual(fwd['M'][i], rev['M'][i], places=10,
+        msg=f"M[{i}] mismatch: Forward={fwd['M'][i]}, Reverse={rev['M'][i]}")


### PR DESCRIPTION
This PR aims at add missing features from the C++ GeographicLib::Geocentric class:

1. Add the following methods:
- Forward() 
- Reverse()
- _Rotation() 
- _Rotate() 
- _Unrotate()
- EquatorialRadius() 
- Flattening()
- WGS84()

2. Add simple tests
3. Update doc generation (though I definitely did not invest time in documenting it, I added a section in code.rst)
4. Update root CMakeList to take into account the Geocentric module & tests

**Notable API changes:**
- Instantiating a Geocentric class using the WGS84 referential is done through a classmethod instead of adding a class variable, as done in Geodesic implementation

**Other info**
- The tests pass :-) `python -m unittest discover geographiclib/test` runs 89 tests with success
- I'm eager to edit this PR based on your review !